### PR TITLE
Add React + TypeScript parallax landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,16 +1,12 @@
 <!DOCTYPE html>
 <html lang="vi">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Order of Ghost Shop</title>
-  <link rel="stylesheet" href="styles.css" />
-  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-</head>
-<body>
-  <div id="root"></div>
-  <script type="text/babel" src="app.jsx"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Order of Ghost</title>
+  </head>
+  <body class="dark">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "order-of-ghost-app",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "framer-motion": "^10.12.16",
+    "locomotive-scroll": "^4.1.4"
+  },
+  "devDependencies": {
+    "vite": "^4.4.9",
+    "@types/react": "^18.2.24",
+    "@types/react-dom": "^18.2.8",
+    "typescript": "^5.2.2",
+    "tailwindcss": "^3.3.5",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.27"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { ScrollContainer } from './components/ScrollContainer';
+import { LoadingScreen } from './components/LoadingScreen';
+import { MusicToggle } from './components/MusicToggle';
+import { Hero } from './sections/Hero';
+import { Features } from './sections/Features';
+import { CultivationRoom } from './sections/CultivationRoom';
+import { AdminCall } from './sections/AdminCall';
+import { Quiz } from './sections/Quiz';
+import { JoinUs } from './sections/JoinUs';
+
+export const App = () => {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setLoading(false), 1500);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <>
+      {loading && <LoadingScreen />}
+      <MusicToggle />
+      <ScrollContainer>
+        <Hero />
+        <Features />
+        <CultivationRoom />
+        <AdminCall />
+        <Quiz />
+        <JoinUs />
+      </ScrollContainer>
+    </>
+  );
+};

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,0 +1,8 @@
+interface AvatarProps {
+  url: string;
+  alt?: string;
+}
+
+export const Avatar = ({ url, alt = 'avatar' }: AvatarProps) => (
+  <img src={url} alt={alt} className="w-10 h-10 rounded-full" />
+);

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,18 @@
+import { motion } from 'framer-motion';
+import { ReactNode } from 'react';
+
+type ButtonProps = {
+  children: ReactNode;
+  onClick?: () => void;
+};
+
+export const Button = ({ children, onClick }: ButtonProps) => (
+  <motion.button
+    whileHover={{ scale: 1.05 }}
+    whileTap={{ scale: 0.95 }}
+    className="px-4 py-2 bg-indigo-600 rounded text-white"
+    onClick={onClick}
+  >
+    {children}
+  </motion.button>
+);

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+interface CardProps {
+  title: string;
+  children?: ReactNode;
+}
+
+export const Card = ({ title, children }: CardProps) => (
+  <div className="bg-gray-800 p-6 rounded shadow-md">
+    <h3 className="text-xl font-semibold mb-2">{title}</h3>
+    <div>{children}</div>
+  </div>
+);

--- a/src/components/GlowingTooltip.tsx
+++ b/src/components/GlowingTooltip.tsx
@@ -1,0 +1,35 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { ReactNode, useState } from 'react';
+
+interface GlowingTooltipProps {
+  text: string;
+  children: ReactNode;
+}
+
+/**
+ * GlowingTooltip displays text above its children when hovered.
+ */
+export const GlowingTooltip = ({ text, children }: GlowingTooltipProps) => {
+  const [show, setShow] = useState(false);
+  return (
+    <div
+      className="relative inline-block"
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+    >
+      <AnimatePresence>
+        {show && (
+          <motion.div
+            className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 text-sm rounded bg-indigo-600 text-white shadow-lg shadow-indigo-500/50"
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+          >
+            {text}
+          </motion.div>
+        )}
+      </AnimatePresence>
+      {children}
+    </div>
+  );
+};

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,23 @@
+import { motion } from 'framer-motion';
+
+/**
+ * LoadingScreen shows a full-screen magical rune spinner on page load.
+ */
+export const LoadingScreen = () => (
+  <motion.div
+    className="fixed inset-0 flex items-center justify-center bg-gray-900 z-50"
+    initial={{ opacity: 1 }}
+    exit={{ opacity: 0 }}
+    transition={{ duration: 0.5 }}
+  >
+    <motion.svg
+      viewBox="0 0 100 100"
+      className="w-32 h-32 text-indigo-400"
+      animate={{ rotate: 360 }}
+      transition={{ repeat: Infinity, duration: 2, ease: 'linear' }}
+    >
+      <circle cx="50" cy="50" r="40" stroke="currentColor" strokeWidth="8" fill="none" />
+      <circle cx="50" cy="50" r="20" stroke="currentColor" strokeWidth="4" fill="none" />
+    </motion.svg>
+  </motion.div>
+);

--- a/src/components/MusicToggle.tsx
+++ b/src/components/MusicToggle.tsx
@@ -1,0 +1,36 @@
+import { useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+
+const AUDIO_SRC = 'https://assets.mixkit.co/music/preview/mixkit-arcade-retro-game-over-213.mp3';
+
+/**
+ * MusicToggle controls playback of background music.
+ */
+export const MusicToggle = () => {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+
+  const toggle = () => {
+    if (!audioRef.current) return;
+    if (playing) {
+      audioRef.current.pause();
+    } else {
+      audioRef.current.play();
+    }
+    setPlaying(!playing);
+  };
+
+  return (
+    <div className="fixed top-4 right-4 z-40">
+      <audio ref={audioRef} src={AUDIO_SRC} loop />
+      <motion.button
+        onClick={toggle}
+        className="p-2 rounded-full bg-gray-800 text-indigo-400 hover:shadow-lg hover:shadow-indigo-500/50"
+        animate={playing ? { scale: [1, 1.1, 1] } : { scale: 1 }}
+        transition={playing ? { repeat: Infinity, duration: 1 } : {}}
+      >
+        {playing ? '🔊' : '🔈'}
+      </motion.button>
+    </div>
+  );
+};

--- a/src/components/ScrollContainer.tsx
+++ b/src/components/ScrollContainer.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+import { useScroll } from '../hooks/useScroll';
+
+interface ScrollContainerProps {
+  children: ReactNode;
+}
+
+export const ScrollContainer = ({ children }: ScrollContainerProps) => {
+  const { containerRef } = useScroll();
+  return (
+    <div data-scroll-container ref={containerRef}>
+      {children}
+    </div>
+  );
+};

--- a/src/core/models/AppUser.ts
+++ b/src/core/models/AppUser.ts
@@ -1,0 +1,12 @@
+import { AppUser } from '../../types/user';
+
+/**
+ * Domain model representing an authenticated user
+ */
+export class User implements AppUser {
+  constructor(
+    public id: string,
+    public name: string,
+    public avatarUrl: string
+  ) {}
+}

--- a/src/core/models/FeatureRelic.ts
+++ b/src/core/models/FeatureRelic.ts
@@ -1,0 +1,13 @@
+import { FeatureRelicProps } from '../../types/feature';
+
+/**
+ * FeatureRelic represents an app feature as a mystical relic.
+ */
+export class FeatureRelic implements FeatureRelicProps {
+  constructor(
+    public id: string,
+    public name: string,
+    public description: string,
+    public icon: string
+  ) {}
+}

--- a/src/core/services/AvatarResolver.ts
+++ b/src/core/services/AvatarResolver.ts
@@ -1,0 +1,10 @@
+/**
+ * AvatarResolver provides avatar urls based on user id.
+ */
+export class AvatarResolver {
+  private base = 'https://api.dicebear.com/7.x/thumbs/svg?seed=';
+
+  getAvatar(userId: string): string {
+    return `${this.base}${encodeURIComponent(userId)}`;
+  }
+}

--- a/src/core/services/QuizService.ts
+++ b/src/core/services/QuizService.ts
@@ -1,0 +1,13 @@
+import { QuizQuestion } from '../../types/quiz';
+
+/**
+ * QuizService handles quiz logic such as verifying answers.
+ */
+export class QuizService {
+  constructor(private questions: QuizQuestion[]) {}
+
+  validate(questionId: string, answerIndex: number): boolean {
+    const q = this.questions.find(qz => qz.id === questionId);
+    return q ? q.correctIndex === answerIndex : false;
+  }
+}

--- a/src/core/services/ScrollManager.ts
+++ b/src/core/services/ScrollManager.ts
@@ -1,0 +1,20 @@
+import LocomotiveScroll from 'locomotive-scroll';
+
+/**
+ * ScrollManager encapsulates initialization of Locomotive Scroll
+ * and exposes basic control methods.
+ */
+export class ScrollManager {
+  private scroll?: LocomotiveScroll;
+
+  init(container: HTMLElement): void {
+    this.scroll = new LocomotiveScroll({
+      el: container,
+      smooth: true
+    });
+  }
+
+  scrollTo(target: string | HTMLElement): void {
+    this.scroll?.scrollTo(target);
+  }
+}

--- a/src/data/features.ts
+++ b/src/data/features.ts
@@ -1,0 +1,8 @@
+import { FeatureRelic } from '../core/models/FeatureRelic';
+
+export const featureRelics = [
+  new FeatureRelic('chatgpt', 'ChatGPT Plus', 'Sức mạnh AI vô song', '🤖'),
+  new FeatureRelic('netflix', 'Netflix', 'Kho phim ma ảo', '🎬'),
+  new FeatureRelic('spotify', 'Spotify', 'Âm nhạc huyền bí', '🎵'),
+  new FeatureRelic('youtube', 'YouTube Premium', 'Xem không quảng cáo', '📺')
+];

--- a/src/data/quiz.ts
+++ b/src/data/quiz.ts
@@ -1,0 +1,10 @@
+import { QuizQuestion } from '../types/quiz';
+
+export const quizQuestions: QuizQuestion[] = [
+  {
+    id: '1',
+    question: 'Đâu là bảo vật mạnh nhất?',
+    answers: ['ChatGPT', 'Netflix', 'Spotify', 'YouTube'],
+    correctIndex: 0
+  }
+];

--- a/src/hooks/useScroll.ts
+++ b/src/hooks/useScroll.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from 'react';
+import { ScrollManager } from '../core/services/ScrollManager';
+
+/**
+ * useScroll initializes Locomotive Scroll on a container element.
+ */
+export const useScroll = () => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const managerRef = useRef<ScrollManager>();
+
+  useEffect(() => {
+    if (containerRef.current) {
+      managerRef.current = new ScrollManager();
+      managerRef.current.init(containerRef.current);
+    }
+  }, []);
+
+  return { containerRef, scroll: managerRef.current };
+};

--- a/src/hooks/useVisibility.ts
+++ b/src/hooks/useVisibility.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * useVisibility observes when an element becomes visible in viewport.
+ */
+export function useVisibility<T extends HTMLElement>() {
+  const [visible, setVisible] = useState(false);
+  const ref = useRef<T | null>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => setVisible(entry.isIntersecting));
+    });
+    if (ref.current) observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, visible };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './styles/tailwind.css';
+import { App } from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/sections/AdminCall.tsx
+++ b/src/sections/AdminCall.tsx
@@ -1,0 +1,13 @@
+import { motion } from 'framer-motion';
+import { Button } from '../components/Button';
+
+export const AdminCall = () => (
+  <section className="py-20" data-scroll-section>
+    <h2 className="text-3xl font-bold text-center mb-6">Huyết Lệnh</h2>
+    <div className="flex justify-center">
+      <motion.div initial={{ scale: 0.8 }} whileInView={{ scale: 1 }}>
+        <Button onClick={() => alert('Lệnh đã nhận!')}>Nhận lệnh</Button>
+      </motion.div>
+    </div>
+  </section>
+);

--- a/src/sections/CultivationRoom.tsx
+++ b/src/sections/CultivationRoom.tsx
@@ -1,0 +1,10 @@
+import { motion } from 'framer-motion';
+
+export const CultivationRoom = () => (
+  <section className="py-20" data-scroll-section>
+    <motion.h2 initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} className="text-3xl font-bold text-center mb-8">
+      Tu Đạo
+    </motion.h2>
+    <p className="text-center">Nâng cao sức mạnh bản thân qua từng nhiệm vụ.</p>
+  </section>
+);

--- a/src/sections/Features.tsx
+++ b/src/sections/Features.tsx
@@ -1,0 +1,19 @@
+import { motion } from 'framer-motion';
+import { featureRelics } from '../data/features';
+import { Card } from '../components/Card';
+import { GlowingTooltip } from '../components/GlowingTooltip';
+
+export const Features = () => (
+  <section className="py-20" data-scroll-section>
+    <h2 className="text-3xl font-bold text-center mb-8">Ngũ Bảo</h2>
+    <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+      {featureRelics.map(relic => (
+        <motion.div key={relic.id} whileInView={{ opacity: 1, y: 0 }} initial={{ opacity: 0, y: 20 }}>
+          <GlowingTooltip text={relic.description}>
+            <Card title={`${relic.icon} ${relic.name}`} />
+          </GlowingTooltip>
+        </motion.div>
+      ))}
+    </div>
+  </section>
+);

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -1,0 +1,12 @@
+import { motion } from 'framer-motion';
+
+export const Hero = () => (
+  <section className="min-h-screen flex flex-col items-center justify-center" data-scroll-section>
+    <motion.h1 initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-5xl font-bold mb-2">
+      Order of Ghost
+    </motion.h1>
+    <motion.p initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.2 }}>
+      Nơi hội tụ của những bảo vật thần bí
+    </motion.p>
+  </section>
+);

--- a/src/sections/JoinUs.tsx
+++ b/src/sections/JoinUs.tsx
@@ -1,0 +1,13 @@
+import { motion } from 'framer-motion';
+import { Button } from '../components/Button';
+
+export const JoinUs = () => (
+  <section className="py-20" data-scroll-section>
+    <h2 className="text-3xl font-bold text-center mb-6">Gia Nhập Hội</h2>
+    <div className="flex justify-center">
+      <motion.div whileHover={{ rotate: 2 }}>
+        <Button onClick={() => alert('Chào mừng bạn!')}>Tham gia ngay</Button>
+      </motion.div>
+    </div>
+  </section>
+);

--- a/src/sections/Quiz.tsx
+++ b/src/sections/Quiz.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { quizQuestions } from '../data/quiz';
+import { QuizService } from '../core/services/QuizService';
+import { Button } from '../components/Button';
+
+const service = new QuizService(quizQuestions);
+
+/**
+ * Quiz section displays a question with selectable answers.
+ */
+export const Quiz = () => {
+  const q = quizQuestions[0];
+  const [error, setError] = useState(false);
+
+  const handleAnswer = (index: number) => {
+    const correct = service.validate(q.id, index);
+    if (!correct) {
+      setError(true);
+      setTimeout(() => setError(false), 600);
+    } else {
+      alert('Chính xác!');
+    }
+  };
+
+  return (
+    <section className="py-20" data-scroll-section>
+      <motion.div
+        className="max-w-md mx-auto bg-gray-800 p-6 rounded shadow-md"
+        animate={error ? { x: [-10, 10, -10, 10, 0] } : { x: 0 }}
+      >
+        <h3 className="text-xl font-semibold mb-4">{q.question}</h3>
+        <ul className="space-y-2">
+          {q.answers.map((a, idx) => (
+            <li key={a}>
+              <Button onClick={() => handleAnswer(idx)}>{a}</Button>
+            </li>
+          ))}
+        </ul>
+        {error && (
+          <motion.div
+            className="mt-4 flex justify-center"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <BrokenRune />
+          </motion.div>
+        )}
+      </motion.div>
+    </section>
+  );
+};
+
+/**
+ * BrokenRune visualizes an incorrect answer with a cracked rune icon.
+ */
+const BrokenRune = () => (
+  <motion.svg
+    viewBox="0 0 24 24"
+    className="w-12 h-12 text-red-500"
+    initial={{ scale: 0 }}
+    animate={{ scale: 1, rotate: [0, 20, -20, 0] }}
+  >
+    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" fill="none" />
+    <path d="M6 6l12 12" stroke="currentColor" strokeWidth="2" />
+  </motion.svg>
+);

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-900 text-gray-100 font-sans;
+}

--- a/src/types/feature.ts
+++ b/src/types/feature.ts
@@ -1,0 +1,6 @@
+export interface FeatureRelicProps {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+}

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -1,0 +1,6 @@
+export interface QuizQuestion {
+  id: string;
+  question: string;
+  answers: string[];
+  correctIndex: number;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,5 @@
+export interface AppUser {
+  id: string;
+  name: string;
+  avatarUrl: string;
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,1 @@
+export const formatCurrency = (v: number) => `${v.toLocaleString()}₫`;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  darkMode: 'class',
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add React + TS frontend with Tailwind dark style
- use OOP classes for models and services
- implement parallax scrolling via Locomotive Scroll
- structure project by clean architecture principles
- add loading screen, glowing tooltips, quiz with error animation, and music toggle

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687092ea668c8321a5f208f4a76a0e76